### PR TITLE
Make `enable_server_side_encryption` and `force_destroy` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ terraform {
 module "terraform_state_backend" {
   source        = "git::https://github.com/cloudposse/terraform-aws-tfstate-backend.git?ref=master"
   namespace     = "cp"
-  stage         = "dev"
-  name          = "app"
+  stage         = "prod"
+  name          = "terraform"
+  attributes    = ["state"]
   region        = "us-east-1"
 }
 ```
@@ -67,18 +68,20 @@ and the DynamoDB table will be used to lock the state to prevent concurrent modi
 
 ## Variables
 
-|  Name                    |  Default     |  Description                                                                      | Required |
-|:-------------------------|:-------------|:----------------------------------------------------------------------------------|:--------:|
-| `namespace`              | ``           | Namespace (_e.g._ `cp` or `cloudposse`)                                           | Yes      |
-| `stage`                  | ``           | Stage (_e.g._ `prod`, `dev`, `staging`)                                           | Yes      |
-| `region`                 | `us-east-1`  | AWS Region the S3 bucket should reside in                                         | Yes      |
-| `name`                   | `terraform`  | Name  (_e.g._ `app`, `cluster`, or `terraform`)                                   | No       |
-| `attributes`             | `["state"]`  | Additional attributes (_e.g._ `policy` or `role`)                                 | No       |
-| `tags`                   | `{}`         | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                              | No       |
-| `delimiter`              | `-`          | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`       | No       |
-| `acl`                    | `private`    | The canned ACL to apply to the S3 bucket                                          | No       |
-| `read_capacity`          | `5`          | DynamoDB read capacity units                                                      | No       |
-| `write_capacity`         | `5`          | DynamoDB write capacity units                                                     | No       |
+|  Name                            |  Default     |  Description                                                                      | Required |
+|:---------------------------------|:-------------|:----------------------------------------------------------------------------------|:--------:|
+| `namespace`                      | ``           | Namespace (_e.g._ `cp` or `cloudposse`)                                           | Yes      |
+| `stage`                          | ``           | Stage (_e.g._ `prod`, `dev`, `staging`)                                           | Yes      |
+| `region`                         | ``           | AWS Region the S3 bucket should reside in                                         | Yes      |
+| `name`                           | `terraform`  | Name  (_e.g._ `app`, `cluster`, or `terraform`)                                   | No       |
+| `attributes`                     | `["state"]`  | Additional attributes (_e.g._ `state`)                                            | No       |
+| `tags`                           | `{}`         | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                              | No       |
+| `delimiter`                      | `-`          | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`       | No       |
+| `acl`                            | `private`    | The canned ACL to apply to the S3 bucket                                          | No       |
+| `read_capacity`                  | `5`          | DynamoDB read capacity units                                                      | No       |
+| `write_capacity`                 | `5`          | DynamoDB write capacity units                                                     | No       |
+| `force_destroy`                  | `false`      | A boolean that indicates the S3 bucket can be destroyed even if it contains objects. These objects are not recoverable   | No       |
+| `enable_server_side_encryption`  | `true`       | Enable DynamoDB server-side encryption                                            | No       |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "aws_s3_bucket" "default" {
   bucket        = "${module.s3_bucket_label.id}"
   acl           = "${var.acl}"
   region        = "${var.region}"
-  force_destroy = false
+  force_destroy = "${var.force_destroy}"
 
   versioning {
     enabled = true
@@ -39,15 +39,35 @@ module "dynamodb_table_label" {
   tags       = "${var.tags}"
 }
 
-resource "aws_dynamodb_table" "default" {
+resource "aws_dynamodb_table" "with_server_side_encryption" {
+  count          = "${var.enable_server_side_encryption == "true" ? 1 : 0}"
   name           = "${module.dynamodb_table_label.id}"
   read_capacity  = "${var.read_capacity}"
   write_capacity = "${var.write_capacity}"
-  hash_key       = "LockID"                            # https://www.terraform.io/docs/backends/types/s3.html#dynamodb_table
+  hash_key       = "LockID"                                                 # https://www.terraform.io/docs/backends/types/s3.html#dynamodb_table
 
   server_side_encryption {
     enabled = true
   }
+
+  lifecycle {
+    ignore_changes = ["read_capacity", "write_capacity"]
+  }
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = "${module.dynamodb_table_label.tags}"
+}
+
+resource "aws_dynamodb_table" "without_server_side_encryption" {
+  count          = "${var.enable_server_side_encryption == "true" ? 0 : 1}"
+  name           = "${module.dynamodb_table_label.id}"
+  read_capacity  = "${var.read_capacity}"
+  write_capacity = "${var.write_capacity}"
+  hash_key       = "LockID"
 
   lifecycle {
     ignore_changes = ["read_capacity", "write_capacity"]

--- a/output.tf
+++ b/output.tf
@@ -11,13 +11,13 @@ output "s3_bucket_arn" {
 }
 
 output "dynamodb_table_name" {
-  value = "${aws_dynamodb_table.default.name}"
+  value = "${element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.name, aws_dynamodb_table.without_server_side_encryption.*.name), 0)}"
 }
 
 output "dynamodb_table_id" {
-  value = "${aws_dynamodb_table.default.id}"
+  value = "${element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.id, aws_dynamodb_table.without_server_side_encryption.*.id), 0)}"
 }
 
 output "dynamodb_table_arn" {
-  value = "${aws_dynamodb_table.default.arn}"
+  value = "${element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.arn, aws_dynamodb_table.without_server_side_encryption.*.arn), 0)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "namespace" {
 
 variable "stage" {
   type        = "string"
-  description = "Stage (e.g. `prod`, `dev`, `staging`, `infra`)"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
@@ -23,19 +23,18 @@ variable "delimiter" {
 variable "attributes" {
   type        = "list"
   default     = ["state"]
-  description = "Additional attributes (e.g. `policy` or `role`)"
+  description = "Additional attributes (e.g. `state`)"
 }
 
 variable "tags" {
   type        = "map"
   default     = {}
-  description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "region" {
   type        = "string"
   description = "AWS Region the S3 bucket should reside in"
-  default     = "us-east-1"
 }
 
 variable "acl" {
@@ -52,4 +51,14 @@ variable "read_capacity" {
 variable "write_capacity" {
   default     = 5
   description = "DynamoDB write capacity units"
+}
+
+variable "force_destroy" {
+  description = "A boolean that indicates the S3 bucket can be destroyed even if it contains objects. These objects are not recoverable"
+  default     = "false"
+}
+
+variable "enable_server_side_encryption" {
+  description = "Enable DynamoDB server-side encryption"
+  default     = "true"
 }


### PR DESCRIPTION
## what
* Make `force_destroy` a variable
* Make `enable_server_side_encryption` a variable

## why
* For some stages (e.g. `dev` or `test`) we need to be able to destroy the bucket (even if it's not empty) when we destroy the environment with Terraform without manually deleting the objects in the bucket
* DynamoDB server-side encryption is currently not supported in some AWS regions (e.g. `eu-west-3`)

## terraform apply
```
dynamodb_table_arn = arn:aws:dynamodb:eu-west-3:XXXXXXXXXX:table/cp-prod-terraform-state-lock
dynamodb_table_id = cp-prod-terraform-state-lock
dynamodb_table_name = cp-prod-terraform-state-lock
s3_bucket_arn = arn:aws:s3:::cp-prod-terraform-state
s3_bucket_domain_name = cp-prod-terraform-state.s3.amazonaws.com
s3_bucket_id = cp-prod-terraform-state
```
