### PR TITLE
Update `terraform-null-label` version. Add `regex_replace_chars` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Available targets:
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `terraform` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
 | read_capacity | DynamoDB read capacity units | string | `5` | no |
+| regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9-]/` | no |
 | region | AWS Region the S3 bucket should reside in | string | - | yes |
 | restrict_public_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | string | `false` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,6 +18,7 @@
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `terraform` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
 | read_capacity | DynamoDB read capacity units | string | `5` | no |
+| regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9-]/` | no |
 | region | AWS Region the S3 bucket should reside in | string | - | yes |
 | restrict_public_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | string | `false` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,19 +1,20 @@
 module "base_label" {
-  source             = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.3"
-  namespace          = "${var.namespace}"
-  environment        = "${var.environment}"
-  stage              = "${var.stage}"
-  name               = "${var.name}"
-  delimiter          = "${var.delimiter}"
-  attributes         = "${var.attributes}"
-  tags               = "${var.tags}"
-  additional_tag_map = "${var.additional_tag_map}"
-  context            = "${var.context}"
-  label_order        = "${var.label_order}"
+  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.6.3"
+  namespace           = "${var.namespace}"
+  environment         = "${var.environment}"
+  stage               = "${var.stage}"
+  name                = "${var.name}"
+  delimiter           = "${var.delimiter}"
+  attributes          = "${var.attributes}"
+  tags                = "${var.tags}"
+  additional_tag_map  = "${var.additional_tag_map}"
+  context             = "${var.context}"
+  label_order         = "${var.label_order}"
+  regex_replace_chars = "${var.regex_replace_chars}"
 }
 
 module "s3_bucket_label" {
-  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.3"
+  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.6.3"
   context = "${module.base_label.context}"
 }
 
@@ -48,7 +49,7 @@ resource "aws_s3_bucket_public_access_block" "default" {
 }
 
 module "dynamodb_table_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.3"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.6.3"
   context    = "${module.base_label.context}"
   attributes = ["${compact(concat(var.attributes, list("lock")))}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -113,3 +113,9 @@ variable "restrict_public_buckets" {
   description = "Whether Amazon S3 should restrict public bucket policies for this bucket."
   default     = false
 }
+
+variable "regex_replace_chars" {
+  type        = "string"
+  default     = "/[^a-zA-Z0-9-]/"
+  description = "Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed"
+}


### PR DESCRIPTION
## what
* Update `terraform-null-label` version
* Add `regex_replace_chars` variable

## why
* Enable hyphens in `var.regex_replace_chars`
* Many users want to use `-` in `name`, `namespace`, `stage`
* Closes #14 
* https://github.com/cloudposse/terraform-null-label/pull/54
* https://github.com/cloudposse/terraform-null-label/issues/49

