### PR TITLE
Add more terraform 0.12 compatibility fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ addons:
       - make
       - curl
 
+env:
+  global:
+    - TERRAFORM_VERSION=0.12.1
+
 install:
   - make init
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 1. Define the module in your `.tf` file using local state:
    ```hcl
    terraform {
-     required_version = ">= 0.11.3"
+     required_version = ">= 0.12.0"
    }
 
    module "terraform_state_backend" {
@@ -80,7 +80,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 1. Then add a `backend` that uses the new bucket and table:
    ```hcl
    terraform {
-     required_version = ">= 0.11.3"
+     required_version = ">= 0.12.0"
 
      backend "s3" {
        region         = "us-east-1"
@@ -124,32 +124,32 @@ Available targets:
 | acl | The canned ACL to apply to the S3 bucket | string | `private` | no |
 | additional_tag_map | Additional tags for appending to each tag map | map | `<map>` | no |
 | attributes | Additional attributes (e.g. `state`) | list | `<list>` | no |
-| block_public_acls | Whether Amazon S3 should block public ACLs for this bucket. | string | `false` | no |
-| block_public_policy | Whether Amazon S3 should block public bucket policies for this bucket. | string | `false` | no |
+| block_public_acls | Whether Amazon S3 should block public ACLs for this bucket. | bool | `false` | no |
+| block_public_policy | Whether Amazon S3 should block public bucket policies for this bucket. | bool | `false` | no |
 | context | Default context to use for passing state between label invocations | map | `<map>` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
-| enable_server_side_encryption | Enable DynamoDB server-side encryption | string | `true` | no |
+| enable_server_side_encryption | Enable DynamoDB server-side encryption | bool | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
-| force_destroy | A boolean that indicates the S3 bucket can be destroyed even if it contains objects. These objects are not recoverable | string | `false` | no |
-| ignore_public_acls | Whether Amazon S3 should ignore public ACLs for this bucket. | string | `false` | no |
+| force_destroy | A boolean that indicates the S3 bucket can be destroyed even if it contains objects. These objects are not recoverable | bool | `false` | no |
+| ignore_public_acls | Whether Amazon S3 should ignore public ACLs for this bucket. | bool | `false` | no |
 | label_order | The naming order of the id output and Name tag | list | `<list>` | no |
-| mfa_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | string | `false` | no |
+| mfa_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | bool | `false` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `terraform` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
-| prevent_unencrypted_uploads | Prevent uploads of unencrypted objects to S3 | string | `true` | no |
+| prevent_unencrypted_uploads | Prevent uploads of unencrypted objects to S3 | bool | `true` | no |
 | profile | AWS profile name as set in the shared credentials file | string | `` | no |
-| read_capacity | DynamoDB read capacity units | string | `5` | no |
+| read_capacity | DynamoDB read capacity units | number | `5` | no |
 | regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9-]/` | no |
 | region | AWS Region the S3 bucket should reside in | string | - | yes |
-| restrict_public_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | string | `false` | no |
+| restrict_public_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | bool | `false` | no |
 | role_arn | The role to be assumed | string | `` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map | `<map>` | no |
 | terraform_backend_config_file_name | Name of terraform backend config file | string | `terraform.tf` | no |
 | terraform_backend_config_file_path | The path to terrafrom project directory | string | `` | no |
 | terraform_state_file | The path to the state file inside the bucket | string | `terraform.tfstate` | no |
-| terraform_version | The minimum required terraform version | string | `0.11.3` | no |
-| write_capacity | DynamoDB write capacity units | string | `5` | no |
+| terraform_version | The minimum required terraform version | string | `0.12.0` | no |
+| write_capacity | DynamoDB write capacity units | number | `5` | no |
 
 ## Outputs
 

--- a/README.yaml
+++ b/README.yaml
@@ -60,7 +60,7 @@ usage: |-
   1. Define the module in your `.tf` file using local state:
      ```hcl
      terraform {
-       required_version = ">= 0.11.3"
+       required_version = ">= 0.12.0"
      }
 
      module "terraform_state_backend" {
@@ -80,7 +80,7 @@ usage: |-
   1. Then add a `backend` that uses the new bucket and table:
      ```hcl
      terraform {
-       required_version = ">= 0.11.3"
+       required_version = ">= 0.12.0"
 
        backend "s3" {
          region         = "us-east-1"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,32 +5,32 @@
 | acl | The canned ACL to apply to the S3 bucket | string | `private` | no |
 | additional_tag_map | Additional tags for appending to each tag map | map | `<map>` | no |
 | attributes | Additional attributes (e.g. `state`) | list | `<list>` | no |
-| block_public_acls | Whether Amazon S3 should block public ACLs for this bucket. | string | `false` | no |
-| block_public_policy | Whether Amazon S3 should block public bucket policies for this bucket. | string | `false` | no |
+| block_public_acls | Whether Amazon S3 should block public ACLs for this bucket. | bool | `false` | no |
+| block_public_policy | Whether Amazon S3 should block public bucket policies for this bucket. | bool | `false` | no |
 | context | Default context to use for passing state between label invocations | map | `<map>` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
-| enable_server_side_encryption | Enable DynamoDB server-side encryption | string | `true` | no |
+| enable_server_side_encryption | Enable DynamoDB server-side encryption | bool | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
-| force_destroy | A boolean that indicates the S3 bucket can be destroyed even if it contains objects. These objects are not recoverable | string | `false` | no |
-| ignore_public_acls | Whether Amazon S3 should ignore public ACLs for this bucket. | string | `false` | no |
+| force_destroy | A boolean that indicates the S3 bucket can be destroyed even if it contains objects. These objects are not recoverable | bool | `false` | no |
+| ignore_public_acls | Whether Amazon S3 should ignore public ACLs for this bucket. | bool | `false` | no |
 | label_order | The naming order of the id output and Name tag | list | `<list>` | no |
-| mfa_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | string | `false` | no |
+| mfa_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | bool | `false` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `terraform` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
-| prevent_unencrypted_uploads | Prevent uploads of unencrypted objects to S3 | string | `true` | no |
+| prevent_unencrypted_uploads | Prevent uploads of unencrypted objects to S3 | bool | `true` | no |
 | profile | AWS profile name as set in the shared credentials file | string | `` | no |
-| read_capacity | DynamoDB read capacity units | string | `5` | no |
+| read_capacity | DynamoDB read capacity units | number | `5` | no |
 | regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9-]/` | no |
 | region | AWS Region the S3 bucket should reside in | string | - | yes |
-| restrict_public_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | string | `false` | no |
+| restrict_public_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | bool | `false` | no |
 | role_arn | The role to be assumed | string | `` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map | `<map>` | no |
 | terraform_backend_config_file_name | Name of terraform backend config file | string | `terraform.tf` | no |
 | terraform_backend_config_file_path | The path to terrafrom project directory | string | `` | no |
 | terraform_state_file | The path to the state file inside the bucket | string | `terraform.tfstate` | no |
-| terraform_version | The minimum required terraform version | string | `0.11.3` | no |
-| write_capacity | DynamoDB write capacity units | string | `5` | no |
+| terraform_version | The minimum required terraform version | string | `0.12.0` | no |
+| write_capacity | DynamoDB write capacity units | number | `5` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,33 +1,33 @@
 locals {
-  prevent_unencrypted_uploads   = "${var.prevent_unencrypted_uploads == "true" && var.enable_server_side_encryption == "true" ? 1 : 0}"
-  policy                        = "${local.prevent_unencrypted_uploads ? join("", data.aws_iam_policy_document.prevent_unencrypted_uploads.*.json) : ""}"
-  terraform_backend_config_file = "${format("%s/%s", var.terraform_backend_config_file_path, var.terraform_backend_config_file_name)}"
+  prevent_unencrypted_uploads   = var.prevent_unencrypted_uploads && var.enable_server_side_encryption
+  policy                        = local.prevent_unencrypted_uploads ? join("", data.aws_iam_policy_document.prevent_unencrypted_uploads.*.json) : ""
+  terraform_backend_config_file = format("%s/%s", var.terraform_backend_config_file_path, var.terraform_backend_config_file_name)
 }
 
 module "base_label" {
-  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.7.0"
-  namespace           = "${var.namespace}"
-  environment         = "${var.environment}"
-  stage               = "${var.stage}"
-  name                = "${var.name}"
-  delimiter           = "${var.delimiter}"
-  attributes          = "${var.attributes}"
-  tags                = "${var.tags}"
-  additional_tag_map  = "${var.additional_tag_map}"
-  context             = "${var.context}"
-  label_order         = "${var.label_order}"
-  regex_replace_chars = "${var.regex_replace_chars}"
+  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.12.0"
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  context             = var.context
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
 }
 
 module "s3_bucket_label" {
-  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.7.0"
-  context = "${module.base_label.context}"
+  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.12.0"
+  context = module.base_label.context
 }
 
 data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
-  count = "${local.prevent_unencrypted_uploads}"
+  count = local.prevent_unencrypted_uploads ? 1 : 0
 
-  statement = {
+  statement {
     sid = "DenyIncorrectEncryptionHeader"
 
     effect = "Deny"
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
     }
   }
 
-  statement = {
+  statement {
     sid = "DenyUnEncryptedObjectUploads"
 
     effect = "Deny"
@@ -85,15 +85,15 @@ data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
 }
 
 resource "aws_s3_bucket" "default" {
-  bucket        = "${module.s3_bucket_label.id}"
-  acl           = "${var.acl}"
-  region        = "${var.region}"
-  force_destroy = "${var.force_destroy}"
-  policy        = "${local.policy}"
+  bucket        = module.s3_bucket_label.id
+  acl           = var.acl
+  region        = var.region
+  force_destroy = var.force_destroy
+  policy        = local.policy
 
   versioning {
     enabled    = true
-    mfa_delete = "${var.mfa_delete}"
+    mfa_delete = var.mfa_delete
   }
 
   server_side_encryption_configuration {
@@ -104,29 +104,29 @@ resource "aws_s3_bucket" "default" {
     }
   }
 
-  tags = "${module.s3_bucket_label.tags}"
+  tags = module.s3_bucket_label.tags
 }
 
 resource "aws_s3_bucket_public_access_block" "default" {
-  bucket                  = "${aws_s3_bucket.default.id}"
-  block_public_acls       = "${var.block_public_acls}"
-  ignore_public_acls      = "${var.ignore_public_acls}"
-  block_public_policy     = "${var.block_public_policy}"
-  restrict_public_buckets = "${var.restrict_public_buckets}"
+  bucket                  = aws_s3_bucket.default.id
+  block_public_acls       = var.block_public_acls
+  ignore_public_acls      = var.ignore_public_acls
+  block_public_policy     = var.block_public_policy
+  restrict_public_buckets = var.restrict_public_buckets
 }
 
 module "dynamodb_table_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.7.0"
-  context    = "${module.base_label.context}"
-  attributes = ["${compact(concat(var.attributes, list("lock")))}"]
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.12.0"
+  context    = module.base_label.context
+  attributes = compact(concat(var.attributes, list("lock")))
 }
 
 resource "aws_dynamodb_table" "with_server_side_encryption" {
-  count          = "${var.enable_server_side_encryption == "true" ? 1 : 0}"
-  name           = "${module.dynamodb_table_label.id}"
-  read_capacity  = "${var.read_capacity}"
-  write_capacity = "${var.write_capacity}"
-  hash_key       = "LockID"                                                 # https://www.terraform.io/docs/backends/types/s3.html#dynamodb_table
+  count          = var.enable_server_side_encryption ? 1 : 0
+  name           = module.dynamodb_table_label.id
+  read_capacity  = var.read_capacity
+  write_capacity = var.write_capacity
+  hash_key       = "LockID" # https://www.terraform.io/docs/backends/types/s3.html#dynamodb_table
 
   server_side_encryption {
     enabled = true
@@ -141,14 +141,14 @@ resource "aws_dynamodb_table" "with_server_side_encryption" {
     type = "S"
   }
 
-  tags = "${module.dynamodb_table_label.tags}"
+  tags = module.dynamodb_table_label.tags
 }
 
 resource "aws_dynamodb_table" "without_server_side_encryption" {
-  count          = "${var.enable_server_side_encryption == "true" ? 0 : 1}"
-  name           = "${module.dynamodb_table_label.id}"
-  read_capacity  = "${var.read_capacity}"
-  write_capacity = "${var.write_capacity}"
+  count          = var.enable_server_side_encryption ? 0 : 1
+  name           = module.dynamodb_table_label.id
+  read_capacity  = var.read_capacity
+  write_capacity = var.write_capacity
   hash_key       = "LockID"
 
   lifecycle {
@@ -160,26 +160,26 @@ resource "aws_dynamodb_table" "without_server_side_encryption" {
     type = "S"
   }
 
-  tags = "${module.dynamodb_table_label.tags}"
+  tags = module.dynamodb_table_label.tags
 }
 
 data "template_file" "terraform_backend_config" {
-  template = "${file("${path.module}/templates/terraform.tf.tpl")}"
+  template = file("${path.module}/templates/terraform.tf.tpl")
 
-  vars {
-    region               = "${var.region}"
-    bucket               = "${aws_s3_bucket.default.id}"
-    dynamodb_table       = "${element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.name, aws_dynamodb_table.without_server_side_encryption.*.name), 0)}"
-    encrypt              = "${var.enable_server_side_encryption == "true" ? "true" : "false"}"
-    role_arn             = "${var.role_arn}"
-    profile              = "${var.profile}"
-    terraform_version    = "${var.terraform_version}"
-    terraform_state_file = "${var.terraform_state_file}"
+  vars = {
+    region               = var.region
+    bucket               = aws_s3_bucket.default.id
+    dynamodb_table       = element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.name, aws_dynamodb_table.without_server_side_encryption.*.name), 0)
+    encrypt              = var.enable_server_side_encryption
+    role_arn             = var.role_arn
+    profile              = var.profile
+    terraform_version    = var.terraform_version
+    terraform_state_file = var.terraform_state_file
   }
 }
 
 resource "local_file" "terraform_backend_config" {
-  count    = "${length(var.terraform_backend_config_file_path) > 0 ? 1 : 0}"
-  content  = "${data.template_file.terraform_backend_config.rendered}"
-  filename = "${local.terraform_backend_config_file}"
+  count    = length(var.terraform_backend_config_file_path) > 0 ? 1 : 0
+  content  = data.template_file.terraform_backend_config.rendered
+  filename = local.terraform_backend_config_file
 }

--- a/output.tf
+++ b/output.tf
@@ -1,34 +1,34 @@
 output "s3_bucket_domain_name" {
-  value       = "${aws_s3_bucket.default.bucket_domain_name}"
+  value       = aws_s3_bucket.default.bucket_domain_name
   description = "S3 bucket domain name"
 }
 
 output "s3_bucket_id" {
-  value       = "${aws_s3_bucket.default.id}"
+  value       = aws_s3_bucket.default.id
   description = "S3 bucket ID"
 }
 
 output "s3_bucket_arn" {
-  value       = "${aws_s3_bucket.default.arn}"
+  value       = aws_s3_bucket.default.arn
   description = "S3 bucket ARN"
 }
 
 output "dynamodb_table_name" {
-  value       = "${element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.name, aws_dynamodb_table.without_server_side_encryption.*.name), 0)}"
+  value       = element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.name, aws_dynamodb_table.without_server_side_encryption.*.name), 0)
   description = "DynamoDB table name"
 }
 
 output "dynamodb_table_id" {
-  value       = "${element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.id, aws_dynamodb_table.without_server_side_encryption.*.id), 0)}"
+  value       = element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.id, aws_dynamodb_table.without_server_side_encryption.*.id), 0)
   description = "DynamoDB table ID"
 }
 
 output "dynamodb_table_arn" {
-  value       = "${element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.arn, aws_dynamodb_table.without_server_side_encryption.*.arn), 0)}"
+  value       = element(coalescelist(aws_dynamodb_table.with_server_side_encryption.*.arn, aws_dynamodb_table.without_server_side_encryption.*.arn), 0)
   description = "DynamoDB table ARN"
 }
 
 output "terraform_backend_config" {
-  value       = "${data.template_file.terraform_backend_config.rendered}"
+  value       = data.template_file.terraform_backend_config.rendered
   description = "Rendered Terraform backend config file"
 }

--- a/templates/terraform.tf.tpl
+++ b/templates/terraform.tf.tpl
@@ -2,12 +2,12 @@ terraform {
   required_version = ">= ${terraform_version}"
 
   backend "s3" {
-    region         = "${region}"
-    bucket         = "${bucket}"
-    key            = "${terraform_state_file}"
-    dynamodb_table = "${dynamodb_table}"
-    profile        = "${profile}"
-    role_arn       = "${role_arn}"
-    encrypt        = "${encrypt}"
+    region         = region
+    bucket         = bucket
+    key            = terraform_state_file
+    dynamodb_table = dynamodb_table
+    profile        = profile
+    role_arn       = role_arn
+    encrypt        = encrypt
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,35 +1,35 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
 }
 
 variable "environment" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT'"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   default     = "terraform"
   description = "Solution name, e.g. 'app' or 'jenkins'"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = ["state"]
   description = "Additional attributes (e.g. `state`)"
 }
@@ -47,111 +47,150 @@ variable "additional_tag_map" {
 }
 
 variable "context" {
-  type        = "map"
-  default     = {}
+  type = object({
+    namespace           = string
+    environment         = string
+    stage               = string
+    name                = string
+    enabled             = bool
+    delimiter           = string
+    attributes          = list(string)
+    label_order         = list(string)
+    tags                = map(string)
+    additional_tag_map  = map(string)
+    regex_replace_chars = string
+  })
+  default = {
+    namespace           = ""
+    environment         = ""
+    stage               = ""
+    name                = ""
+    enabled             = true
+    delimiter           = ""
+    attributes          = []
+    label_order         = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = ""
+  }
   description = "Default context to use for passing state between label invocations"
 }
 
 variable "label_order" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "The naming order of the id output and Name tag"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS Region the S3 bucket should reside in"
 }
 
 variable "acl" {
-  type        = "string"
+  type        = string
   description = "The canned ACL to apply to the S3 bucket"
   default     = "private"
 }
 
 variable "read_capacity" {
+  type        = number
   default     = 5
   description = "DynamoDB read capacity units"
 }
 
 variable "write_capacity" {
+  type        = number
   default     = 5
   description = "DynamoDB write capacity units"
 }
 
 variable "force_destroy" {
+  type        = bool
+  default     = false
   description = "A boolean that indicates the S3 bucket can be destroyed even if it contains objects. These objects are not recoverable"
-  default     = "false"
 }
 
 variable "mfa_delete" {
+  type        = bool
+  default     = false
   description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
-  default     = "false"
 }
 
 variable "enable_server_side_encryption" {
+  type        = bool
+  default     = true
   description = "Enable DynamoDB server-side encryption"
-  default     = "true"
 }
 
 variable "block_public_acls" {
-  description = "Whether Amazon S3 should block public ACLs for this bucket."
+  type        = bool
   default     = false
+  description = "Whether Amazon S3 should block public ACLs for this bucket."
 }
 
 variable "ignore_public_acls" {
-  description = "Whether Amazon S3 should ignore public ACLs for this bucket."
+  type        = bool
   default     = false
+  description = "Whether Amazon S3 should ignore public ACLs for this bucket."
 }
 
 variable "block_public_policy" {
-  description = "Whether Amazon S3 should block public bucket policies for this bucket."
+  type        = bool
   default     = false
+  description = "Whether Amazon S3 should block public bucket policies for this bucket."
 }
 
 variable "restrict_public_buckets" {
-  description = "Whether Amazon S3 should restrict public bucket policies for this bucket."
+  type        = bool
   default     = false
+  description = "Whether Amazon S3 should restrict public bucket policies for this bucket."
 }
 
 variable "regex_replace_chars" {
-  type        = "string"
+  type        = string
   default     = "/[^a-zA-Z0-9-]/"
   description = "Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed"
 }
 
 variable "prevent_unencrypted_uploads" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Prevent uploads of unencrypted objects to S3"
 }
 
 variable "profile" {
+  type        = string
   default     = ""
   description = "AWS profile name as set in the shared credentials file"
 }
 
 variable "role_arn" {
+  type        = string
   default     = ""
   description = "The role to be assumed"
 }
 
 variable "terraform_backend_config_file_name" {
+  type        = string
   default     = "terraform.tf"
   description = "Name of terraform backend config file"
 }
 
 variable "terraform_backend_config_file_path" {
+  type        = string
   default     = ""
   description = "The path to terrafrom project directory"
 }
 
 variable "terraform_version" {
-  default     = "0.11.3"
+  type        = string
+  default     = "0.12.0"
   description = "The minimum required terraform version"
 }
 
 variable "terraform_state_file" {
+  type        = string
   default     = "terraform.tfstate"
   description = "The path to the state file inside the bucket"
 }


### PR DESCRIPTION
This PR adds more fixes for 0.12 compatibility, notably around type-casting.

Please merge [#12](https://github.com/cloudposse/terraform-aws-tfstate-backend/pull/22) beforehand.