### PR TITLE
Set appropriate AWS ARN for S3 bucket policies in GovCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | acl | The canned ACL to apply to the S3 bucket | string | `private` | no |
 | additional_tag_map | Additional tags for appending to each tag map | map(string) | `<map>` | no |
+| arn_format | ARN format to be used. May be changed to support deployment in GovCloud/China regions. | string | `arn:aws` | no |
 | attributes | Additional attributes (e.g. `state`) | list(string) | `<list>` | no |
 | billing_mode | DynamoDB billing mode | string | `PROVISIONED` | no |
 | block_public_acls | Whether Amazon S3 should block public ACLs for this bucket | bool | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,6 +4,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | acl | The canned ACL to apply to the S3 bucket | string | `private` | no |
 | additional_tag_map | Additional tags for appending to each tag map | map(string) | `<map>` | no |
+| arn_format | ARN format to be used. May be changed to support deployment in GovCloud/China regions. | string | `arn:aws` | no |
 | attributes | Additional attributes (e.g. `state`) | list(string) | `<list>` | no |
 | billing_mode | DynamoDB billing mode | string | `PROVISIONED` | no |
 | block_public_acls | Whether Amazon S3 should block public ACLs for this bucket | bool | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
     ]
 
     resources = [
-      "arn:aws:s3:::${local.bucket_name}/*",
+      "${var.arn_format}:s3:::${local.bucket_name}/*",
     ]
 
     condition {
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
     ]
 
     resources = [
-      "arn:aws:s3:::${local.bucket_name}/*",
+      "${var.arn_format}:s3:::${local.bucket_name}/*",
     ]
 
     condition {

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "region" {
   description = "AWS Region the S3 bucket should reside in"
 }
 
+variable "arn_format" {
+  type        = string
+  default     = "arn:aws"
+  description = "ARN format to be used. May be changed to support deployment in GovCloud/China regions."
+}
+
 variable "acl" {
   type        = string
   description = "The canned ACL to apply to the S3 bucket"


### PR DESCRIPTION
## What
* Parameterize the ARN prefix used for S3 bucket policies such that if we are deploying in an AWS GovCloud region, the ARN prefix is `arn:aws-us-gov:s3`. Otherwise, the ARN prefix is `arn:aws:s3`.

## Why
* These changes allow successful deployment in GovCloud (tested in `us-gov-west-1`). Prior to this change, attempting to deploy in GovCloud would fail with:

```
Error: Error putting S3 policy: MalformedPolicy: Policy has invalid resource status code: 400
```

## References
* https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-arns.html

