### PR TITLE
Add China arn compatibility. Use arn_prefix var for determinate which…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,8 @@ locals {
   terraform_backend_config_template_file = var.terraform_backend_config_template_file != "" ? var.terraform_backend_config_template_file : "${path.module}/templates/terraform.tf.tpl"
 
   bucket_name = var.s3_bucket_name != "" ? var.s3_bucket_name : module.s3_bucket_label.id
+
+  arn_prefix = "${substr(var.region, 0, 3) == "cn-" ? "arn:aws-cn" : var.arn_prefix}"
 }
 
 module "base_label" {
@@ -55,7 +57,7 @@ data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
     ]
 
     resources = [
-      "arn:aws:s3:::${local.bucket_name}/*",
+      "${local.arn_prefix}:s3:::${local.bucket_name}/*",
     ]
 
     condition {
@@ -83,7 +85,7 @@ data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
     ]
 
     resources = [
-      "arn:aws:s3:::${local.bucket_name}/*",
+      "${local.arn_prefix}:s3:::${local.bucket_name}/*",
     ]
 
     condition {

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "region" {
   description = "AWS Region the S3 bucket should reside in"
 }
 
+variable "arn_prefix" {
+  type        = string
+  description = "AWS ARN prefix of resources. Because in China is different from the another regions"
+  default     = "arn:aws"
+}
+
 variable "acl" {
   type        = string
   description = "The canned ACL to apply to the S3 bucket"


### PR DESCRIPTION
 Add China arn compatibility. Use arn_prefix var for determinate which  ARN to use

## what
* Adapt the AWS ARN prefix pour S3 bucket resource. 
* Add a  'arn_prefix' local var in main.tf, the value is set related of the AWS region var.
* In the S3 bucket policy template, add the 'local.arn_prefix' var in prefix of resources.
* the 'arn_prefix' default value is set to 'arn:aws"

## why
* Because for China region the ARN is 'arn:aws-cn', instead of 'arn:aws' for all other regions.
* It would be best if this module is available for all AWS regions. 
* In my business case we deploy in many regions, included China. 

## references
* no reference, business case encountered in China region deployments.

