### PR TITLE
Extend S3 bucket policy to ensure encryption-in-transit

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Slash Command Dispatch
-        uses: cloudposse/actions/github/slash-command-dispatch@0.12.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.15.0
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Slash Command Dispatch
         uses: cloudposse/actions/github/slash-command-dispatch@0.15.0
         with:
-          token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          reaction-token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: cloudposse/actions
           commands: rebuild-readme, terraform-fmt
           permission: none

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Slash Command Dispatch
-        uses: cloudposse/actions/github/slash-command-dispatch@0.15.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.12.0
         with:
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-          reaction-token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: rebuild-readme, terraform-fmt
           permission: none

--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,30 @@ data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
       ]
     }
   }
+
+  statement {
+    sid = "EnforceTlsRequestsOnly"
+
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      "${var.arn_format}:s3:::${local.bucket_name}",
+      "${var.arn_format}:s3:::${local.bucket_name}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 }
 
 resource "aws_s3_bucket" "default" {


### PR DESCRIPTION
Whilst the current option policy ensures server-side encryption,
encryption of the transport mechanism isn't enforced.

This change extends the S3 bucket policy to enforce encryption in
transit, which is necessary to satisfy the s3-bucket-ssl-requests-only
AWS Config Rule[1]

Given the option to prevent unencrypted uploads is already present,
and this change fits in the spirit of that, I've not introduced a
separate flag for this behaviour.

[1] https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html
