### PR TITLE
add list with an empty string, necessary for terraform 0.12 destroy

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -29,7 +29,8 @@ output "dynamodb_table_id" {
   value = element(
     coalescelist(
       aws_dynamodb_table.with_server_side_encryption.*.id,
-      aws_dynamodb_table.without_server_side_encryption.*.id
+      aws_dynamodb_table.without_server_side_encryption.*.id,
+      [""]
     ),
     0
   )
@@ -40,7 +41,8 @@ output "dynamodb_table_arn" {
   value = element(
     coalescelist(
       aws_dynamodb_table.with_server_side_encryption.*.arn,
-      aws_dynamodb_table.without_server_side_encryption.*.arn
+      aws_dynamodb_table.without_server_side_encryption.*.arn,
+      [""]
     ),
     0
   )


### PR DESCRIPTION

## what
Add the missing empty string list to coalesce() call

I have not tested whether this breaks terraform 0.11 destroy, but based on what I read it should not.

## why
* without this fix, issue #51 arises for terraform 0.12 destroy

## references
- https://github.com/hashicorp/terraform/issues/21370
- https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/issues/104
- `closes #51`

