### PR TITLE
Allow users to encrypt with KMS instead of only with SSE

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,7 @@ data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
 
       values = [
         "AES256",
+        "aws:kms",
       ]
     }
   }


### PR DESCRIPTION
## What this change is for
* This change prevents a 403 access denied error when using a kms_key_id with the tfstate backend.

```
failed to upload state: AccessDenied: Access Denied
	status code: 403
```

## Why this change is needed
* The existing code prevents you from using different KMS keys for different state files in S3.
* The changes allow the use of specific KMS keys, to further protect sensitive data in S3.


