### PR TITLE
fix: update null label version to 0.17.0 to fix issues with tf 0.13

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "base_label" {
-  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
   namespace           = var.namespace
   environment         = var.environment
   stage               = var.stage
@@ -33,7 +33,7 @@ module "base_label" {
 }
 
 module "s3_bucket_label" {
-  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
   context = module.base_label.context
 }
 
@@ -154,7 +154,7 @@ resource "aws_s3_bucket_public_access_block" "default" {
 }
 
 module "dynamodb_table_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
   context    = module.base_label.context
   attributes = compact(concat(var.attributes, ["lock"]))
 }


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

## what
* Update the version of `terraform-null-label` to 0.17.0 

## why
* This was required for using this module with terraform 013.0

## references
fixes #58
