### PR TITLE
Updates local output file to have normal file permissions - not 777

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -248,7 +248,8 @@ data "template_file" "terraform_backend_config" {
 }
 
 resource "local_file" "terraform_backend_config" {
-  count    = var.terraform_backend_config_file_path != "" ? 1 : 0
-  content  = data.template_file.terraform_backend_config.rendered
-  filename = local.terraform_backend_config_file
+  count           = var.terraform_backend_config_file_path != "" ? 1 : 0
+  content         = data.template_file.terraform_backend_config.rendered
+  filename        = local.terraform_backend_config_file
+  file_permission = "0644"
 }


### PR DESCRIPTION
## what

* Updates the `terraform_backend_config` file's permissions to be 644 > 777

## why

* Terraform's local_file creates permissions with 777 by default, which is odd. Using 644 is more sane and should keep file permissions in line with most system new file defaults.
