### PR TITLE
var.enable_dynamodb fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -213,7 +213,7 @@ resource "aws_dynamodb_table" "with_server_side_encryption" {
 }
 
 resource "aws_dynamodb_table" "without_server_side_encryption" {
-  count          = var.enable_dynamodb && var.enable_server_side_encryption ? 0 : 1
+  count          = var.enable_dynamodb || var.enable_server_side_encryption ? 0 : 1
   name           = module.dynamodb_table_label.id
   billing_mode   = var.billing_mode
   read_capacity  = var.billing_mode == "PROVISIONED" ? var.read_capacity : null


### PR DESCRIPTION
## what
I didn't realize in the last PR that the 0 and the 1 were swapped for the aws_dynamodb_table.without_server_side_encryption resource. 

## why
* Fixes an issue with the var.enable_dynamodb PR https://github.com/cloudposse/terraform-aws-tfstate-backend/pull/65

