### PR TITLE
fix(readme): remove region input var from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Follow this procedure just once to create your deployment.
       stage      = "test"
       name       = "terraform"
       attributes = ["state"]
-      region     = "us-east-1"
 
       terraform_backend_config_file_path = "."
       terraform_backend_config_file_name = "backend.tf"
@@ -186,7 +185,6 @@ To enable S3 bucket replication in this module, set `s3_replication_enabled` to 
       stage      = "test"
       name       = "terraform"
       attributes = ["state"]
-      region     = "us-east-1"
 
       terraform_backend_config_file_path = "."
       terraform_backend_config_file_name = "backend.tf"

--- a/README.yaml
+++ b/README.yaml
@@ -73,7 +73,6 @@ usage: |-
         stage      = "test"
         name       = "terraform"
         attributes = ["state"]
-        region     = "us-east-1"
 
         terraform_backend_config_file_path = "."
         terraform_backend_config_file_name = "backend.tf"
@@ -160,7 +159,6 @@ usage: |-
         stage      = "test"
         name       = "terraform"
         attributes = ["state"]
-        region     = "us-east-1"
 
         terraform_backend_config_file_path = "."
         terraform_backend_config_file_name = "backend.tf"


### PR DESCRIPTION
## what
Removed `region` as input var to the module from the examples.

## why
The 0.25.0 version removed the static aws `region` input as var.
