### PR TITLE
Fix: support `tenant` label by updating version of null-label module for `aws_dynamodb_table`

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_dynamodb_table_label"></a> [dynamodb\_table\_label](#module\_dynamodb\_table\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_dynamodb_table_label"></a> [dynamodb\_table\_label](#module\_dynamodb\_table\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,7 +19,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_dynamodb_table_label"></a> [dynamodb\_table\_label](#module\_dynamodb\_table\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_dynamodb_table_label"></a> [dynamodb\_table\_label](#module\_dynamodb\_table\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -193,7 +193,7 @@ resource "aws_s3_bucket_public_access_block" "default" {
 
 module "dynamodb_table_label" {
   source     = "cloudposse/label/null"
-  version    = "0.24.1"
+  version    = "0.25.0"
   attributes = ["lock"]
   context    = module.this.context
   enabled    = local.dynamodb_enabled


### PR DESCRIPTION
## what
* Bump `null-label` module for `aws_dynamodb_table` resource to `0.25.0` in order to support `tenant` label.

## why
* `context.tf` in this module supports `tenant` because its instantiation of `null-label` has been auto-updated to `0.25.0`, but the instantiation of `null-label` module for the `aws_dynamodb_table` resource has not been updated.

## references
* https://github.com/cloudposse/terraform-null-label/releases/tag/0.25.0

