### PR TITLE
Fix/dynamodb encryption logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,6 @@ Available targets:
 | Name | Type |
 |------|------|
 | [aws_dynamodb_table.with_server_side_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
-| [aws_dynamodb_table.without_server_side_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_iam_policy.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,7 +27,6 @@
 | Name | Type |
 |------|------|
 | [aws_dynamodb_table.with_server_side_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
-| [aws_dynamodb_table.without_server_side_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_iam_policy.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,7 +8,8 @@ module "tfstate_backend" {
   force_destroy = true
 
   bucket_enabled   = var.bucket_enabled
-  dynamodb_enabled = var.dynamodb_enabled
+  dynamodb_enabled = false
+  enable_server_side_encryption = false
 
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,8 +8,7 @@ module "tfstate_backend" {
   force_destroy = true
 
   bucket_enabled   = var.bucket_enabled
-  dynamodb_enabled = false
-  enable_server_side_encryption = false
+  dynamodb_enabled = var.dynamodb_enabled
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -249,7 +249,7 @@ resource "aws_dynamodb_table" "with_server_side_encryption" {
 }
 
 resource "aws_dynamodb_table" "without_server_side_encryption" {
-  count          = local.dynamodb_enabled && ! var.enable_server_side_encryption ? 1 : 0
+  count          = local.dynamodb_enabled && !var.enable_server_side_encryption ? 1 : 0
   name           = local.dynamodb_table_name
   billing_mode   = var.billing_mode
   read_capacity  = var.billing_mode == "PROVISIONED" ? var.read_capacity : null

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ locals {
     region = data.aws_region.current.name
     bucket = join("", aws_s3_bucket.default.*.id)
 
-    dynamodb_table = local.dynamodb_enabled ? aws_dynamodb_table.default[0].name : ""
+    dynamodb_table = local.dynamodb_enabled ? aws_dynamodb_table.with_server_side_encryption[0].name : ""
 
     encrypt              = var.enable_server_side_encryption ? "true" : "false"
     role_arn             = var.role_arn
@@ -216,7 +216,7 @@ module "dynamodb_table_label" {
   enabled    = local.dynamodb_enabled
 }
 
-resource "aws_dynamodb_table" "default" {
+resource "aws_dynamodb_table" "with_server_side_encryption" {
   count          = local.dynamodb_enabled ? 1 : 0
   name           = local.dynamodb_table_name
   billing_mode   = var.billing_mode

--- a/main.tf
+++ b/main.tf
@@ -249,7 +249,7 @@ resource "aws_dynamodb_table" "with_server_side_encryption" {
 }
 
 resource "aws_dynamodb_table" "without_server_side_encryption" {
-  count          = local.dynamodb_enabled && !var.enable_server_side_encryption ? 1 : 0
+  count          = local.dynamodb_enabled && ! var.enable_server_side_encryption ? 1 : 0
   name           = local.dynamodb_table_name
   billing_mode   = var.billing_mode
   read_capacity  = var.billing_mode == "PROVISIONED" ? var.read_capacity : null

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "s3_bucket_arn" {
 }
 
 output "dynamodb_table_name" {
-  value = local.dynamodb_table_name
+  value       = local.dynamodb_table_name
   description = "DynamoDB table name"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,8 +16,7 @@ output "s3_bucket_arn" {
 output "dynamodb_table_name" {
   value = element(
     coalescelist(
-      aws_dynamodb_table.with_server_side_encryption.*.name,
-      aws_dynamodb_table.without_server_side_encryption.*.name,
+      aws_dynamodb_table.default.*.name,
       [""]
     ),
     0
@@ -28,8 +27,7 @@ output "dynamodb_table_name" {
 output "dynamodb_table_id" {
   value = element(
     coalescelist(
-      aws_dynamodb_table.with_server_side_encryption.*.id,
-      aws_dynamodb_table.without_server_side_encryption.*.id,
+      aws_dynamodb_table.default.*.id,
       [""]
     ),
     0
@@ -40,8 +38,7 @@ output "dynamodb_table_id" {
 output "dynamodb_table_arn" {
   value = element(
     coalescelist(
-      aws_dynamodb_table.with_server_side_encryption.*.arn,
-      aws_dynamodb_table.without_server_side_encryption.*.arn,
+      aws_dynamodb_table.default.*.arn,
       [""]
     ),
     0

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,7 +16,7 @@ output "s3_bucket_arn" {
 output "dynamodb_table_name" {
   value = element(
     coalescelist(
-      aws_dynamodb_table.default.*.name,
+      aws_dynamodb_table.with_server_side_encryption.*.name,
       [""]
     ),
     0
@@ -27,7 +27,7 @@ output "dynamodb_table_name" {
 output "dynamodb_table_id" {
   value = element(
     coalescelist(
-      aws_dynamodb_table.default.*.id,
+      aws_dynamodb_table.with_server_side_encryption.*.id,
       [""]
     ),
     0
@@ -38,7 +38,7 @@ output "dynamodb_table_id" {
 output "dynamodb_table_arn" {
   value = element(
     coalescelist(
-      aws_dynamodb_table.default.*.arn,
+      aws_dynamodb_table.with_server_side_encryption.*.arn,
       [""]
     ),
     0

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,14 +14,7 @@ output "s3_bucket_arn" {
 }
 
 output "dynamodb_table_name" {
-  value = element(
-    coalescelist(
-      aws_dynamodb_table.with_server_side_encryption.*.name,
-      aws_dynamodb_table.without_server_side_encryption.*.name,
-      [""]
-    ),
-    0
-  )
+  value = local.dynamodb_table_name
   description = "DynamoDB table name"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,14 @@ output "s3_bucket_arn" {
 }
 
 output "dynamodb_table_name" {
-  value       = local.dynamodb_table_name
+  value = element(
+    coalescelist(
+      aws_dynamodb_table.with_server_side_encryption.*.name,
+      aws_dynamodb_table.without_server_side_encryption.*.name,
+      [""]
+    ),
+    0
+  )
   description = "DynamoDB table name"
 }
 


### PR DESCRIPTION
## what
Use a single dynamodb table wich configurable server-side encryption instead of one `without_server_side_encryption` and another `with_server_side_encryption`

## why
Fix:
 [bridgecrew bot security report](https://github.com/cloudposse/terraform-aws-tfstate-backend/pull/103#discussion_r744110496): `Ensure DynamoDB Tables have Auto Scaling enabled`
