### PR TITLE
Decoupling various resources from context module

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,5 +10,17 @@ module "tfstate_backend" {
   bucket_enabled   = var.bucket_enabled
   dynamodb_enabled = var.dynamodb_enabled
 
+  s3_replication_enabled = true
+  s3_replica_bucket_arn  = module.tstate_backend_replication.s3_bucket_arn
+
   context = module.this.context
+}
+
+module "tstate_backend_replication" {
+  source = "../../"
+
+  s3_bucket_name   = "${module.this.id}-replica"
+  force_destroy    = true
+  dynamodb_enabled = false
+
 }

--- a/main.tf
+++ b/main.tf
@@ -182,7 +182,7 @@ resource "aws_s3_bucket" "default" {
       role = aws_iam_role.replication[0].arn
 
       rules {
-        id     = module.this.id
+        id     = var.s3_bucket_name != "" ? var.s3_bucket_name : module.this.id
         prefix = ""
         status = "Enabled"
 

--- a/replication.tf
+++ b/replication.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "replication" {
   count = local.enabled && var.s3_replication_enabled ? 1 : 0
 
-  name               = format("%s-replication", module.this.id)
+  name               = format("%s-replication", var.s3_bucket_name != "" ? var.s3_bucket_name : module.this.id)
   assume_role_policy = data.aws_iam_policy_document.replication_sts[0].json
 }
 
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "replication_sts" {
 resource "aws_iam_policy" "replication" {
   count = local.enabled && var.s3_replication_enabled ? 1 : 0
 
-  name   = format("%s-replication", module.this.id)
+  name   = format("%s-replication", var.s3_bucket_name != "" ? var.s3_bucket_name : module.this.id)
   policy = data.aws_iam_policy_document.replication[0].json
 }
 


### PR DESCRIPTION
Removing dependency on some resources (such as IAM role, policy, and
bucket replication rule) from the [label module](https://github.com/cloudposse/terraform-aws-tfstate-backend/blob/master/examples/complete/context.tf#L23).
Also added replication to the complete example.

