### PR TITLE
S3 resource supports AWS provider v4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -207,20 +207,20 @@ resource "aws_s3_bucket" "default" {
 
 # Bucket policy
 resource "aws_s3_bucket_policy" "prevent_unencrypted_uploads" {
-  bucket = aws_s3_bucket.default.id
+  bucket = aws_s3_bucket.default[0].id
   policy = local.policy
 }
 
 # S3 acl resource support for AWS provider V4
 resource "aws_s3_bucket_acl" "default" {
-  bucket = aws_s3_bucket.default.id
+  bucket = aws_s3_bucket.default[0].id
   acl    = var.acl
 }
 
 # S3 logging resource support for AWS provider v4
 resource "aws_s3_bucket_logging" "default" {
   for_each = var.logging == null ? [] : [1]
-  bucket   = aws_s3_bucket.default.id
+  bucket   = aws_s3_bucket.default[0].id
 
   target_bucket = local.logging_bucket_name
   target_prefix = local.logging_prefix
@@ -228,7 +228,7 @@ resource "aws_s3_bucket_logging" "default" {
 
 # S3 versioning resource support for AWS provider v4
 resource "aws_s3_bucket_versioning" "default" {
-  bucket = aws_s3_bucket.default.id
+  bucket = aws_s3_bucket.default[0].id
   versioning_configuration {
     status     = "Enabled"
     mfa_delete = var.mfa_delete
@@ -237,7 +237,7 @@ resource "aws_s3_bucket_versioning" "default" {
 
 # S3 server side encryption support for AWS provider v4
 resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
-  bucket = aws_s3_bucket.default.bucket
+  bucket = aws_s3_bucket.default[0].bucket
 
   rule {
     apply_server_side_encryption_by_default {
@@ -253,7 +253,7 @@ resource "aws_s3_bucket_replication_configuration" "default" {
   depends_on = [aws_s3_bucket_versioning.default]
 
   role   = aws_iam_role.replication[0].arn
-  bucket = aws_s3_bucket.default.id
+  bucket = aws_s3_bucket.default[0].id
 
   rule {
     id     = module.this.id

--- a/main.tf
+++ b/main.tf
@@ -138,21 +138,6 @@ data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
   }
 }
 
-# module "log_storage" {
-#   source  = "cloudposse/s3-log-storage/aws"
-#   version = "0.26.0"
-
-#   enabled                  = local.logging_bucket_enabled
-#   access_log_bucket_prefix = local.logging_prefix_default
-#   acl                      = "log-delivery-write"
-#   expiration_days          = var.logging_bucket_expiration_days
-#   glacier_transition_days  = var.logging_bucket_glacier_transition_days
-#   name                     = local.logging_bucket_name_default
-#   standard_transition_days = var.logging_bucket_standard_transition_days
-
-#   context = module.this.context
-# }
-
 module "log_storage" {
   source                   = "cloudposse/s3-log-storage/aws"
   version                  = "0.28.0"
@@ -190,51 +175,9 @@ resource "aws_s3_bucket" "default" {
 
   #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` check until Bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   #bridgecrew:skip=CKV_AWS_52:Skipping `Ensure S3 bucket has MFA delete enabled` check due to issues operating with `mfa_delete` in terraform
-  bucket = substr(local.bucket_name, 0, 63)
-  # acl           = var.acl
+  bucket        = substr(local.bucket_name, 0, 63)
   force_destroy = var.force_destroy
-  # policy        = local.policy
-
-  # versioning {
-  #   enabled    = true
-  #   mfa_delete = var.mfa_delete
-  # }
-
-  # server_side_encryption_configuration {
-  #   rule {
-  #     apply_server_side_encryption_by_default {
-  #       sse_algorithm = "AES256"
-  #     }
-  #   }
-  # }
-
-  # dynamic "replication_configuration" {
-  #   for_each = var.s3_replication_enabled ? toset([var.s3_replica_bucket_arn]) : []
-  #   content {
-  #     role = aws_iam_role.replication[0].arn
-
-  #     rules {
-  #       id     = module.this.id
-  #       prefix = ""
-  #       status = "Enabled"
-
-  #       destination {
-  #         bucket        = var.s3_replica_bucket_arn
-  #         storage_class = "STANDARD"
-  #       }
-  #     }
-  #   }
-  # }
-
-  # dynamic "logging" {
-  #   for_each = var.logging == null ? [] : [1]
-  #   content {
-  #     target_bucket = local.logging_bucket_name
-  #     target_prefix = local.logging_prefix
-  #   }
-  # }
-
-  tags = module.this.tags
+  tags          = module.this.tags
 }
 
 # Bucket policy

--- a/main.tf
+++ b/main.tf
@@ -251,7 +251,7 @@ resource "aws_s3_bucket_acl" "default" {
 
 # S3 logging resource support for AWS provider v4
 resource "aws_s3_bucket_logging" "default" {
-  for_each = var.logging == null ? [] : [1]
+  for_each = var.logging == null ? toset([]) : toset([1])
   bucket   = aws_s3_bucket.default[0].id
 
   target_bucket = local.logging_bucket_name
@@ -263,7 +263,7 @@ resource "aws_s3_bucket_versioning" "default" {
   bucket = aws_s3_bucket.default[0].id
   versioning_configuration {
     status     = "Enabled"
-    mfa_delete = var.mfa_delete
+    mfa_delete = var.mfa_delete ? "Enabled" : "Disabled"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -251,7 +251,7 @@ resource "aws_s3_bucket_acl" "default" {
 
 # S3 logging resource support for AWS provider v4
 resource "aws_s3_bucket_logging" "default" {
-  for_each = var.logging == null ? toset([]) : toset([1])
+  for_each = var.logging == null ? toset([]) : toset(["true"])
   bucket   = aws_s3_bucket.default[0].id
 
   target_bucket = local.logging_bucket_name


### PR DESCRIPTION
## what
* Modified `aws_s3_bucket` resource to support AWS provider v4.
* Upgraded `cloudposse/s3-log-storage/aws` module to `0.28.0` to support AWS provider v4.

## why
* Current `aws_s3_bucket` resource does not support AWS provider v4.


