### PR TITLE
Adding support for setting permissions boundary on IAM-role

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 
@@ -523,7 +523,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-tfstate-backend&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-tfstate-backend&utm_content=website
@@ -554,3 +554,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-tfstate-backend
   [share_email]: mailto:?subject=terraform-aws-tfstate-backend&body=https://github.com/cloudposse/terraform-aws-tfstate-backend
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-tfstate-backend?pixel&cs=github&cm=readme&an=terraform-aws-tfstate-backend
+<!-- markdownlint-restore -->

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Available targets:
 | <a name="input_mfa_delete"></a> [mfa\_delete](#input\_mfa\_delete) | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `""` | no |
 | <a name="input_prevent_unencrypted_uploads"></a> [prevent\_unencrypted\_uploads](#input\_prevent\_unencrypted\_uploads) | Prevent uploads of unencrypted objects to S3 | `bool` | `true` | no |
 | <a name="input_profile"></a> [profile](#input\_profile) | AWS profile name as set in the shared credentials file | `string` | `""` | no |
 | <a name="input_read_capacity"></a> [read\_capacity](#input\_read\_capacity) | DynamoDB read capacity units | `number` | `5` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -76,6 +76,7 @@
 | <a name="input_mfa_delete"></a> [mfa\_delete](#input\_mfa\_delete) | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `""` | no |
 | <a name="input_prevent_unencrypted_uploads"></a> [prevent\_unencrypted\_uploads](#input\_prevent\_unencrypted\_uploads) | Prevent uploads of unencrypted objects to S3 | `bool` | `true` | no |
 | <a name="input_profile"></a> [profile](#input\_profile) | AWS profile name as set in the shared credentials file | `string` | `""` | no |
 | <a name="input_read_capacity"></a> [read\_capacity](#input\_read\_capacity) | DynamoDB read capacity units | `number` | `5` | no |

--- a/main.tf
+++ b/main.tf
@@ -249,7 +249,7 @@ resource "aws_dynamodb_table" "with_server_side_encryption" {
 }
 
 resource "aws_dynamodb_table" "without_server_side_encryption" {
-  count          = local.dynamodb_enabled && ! var.enable_server_side_encryption ? 1 : 0
+  count          = local.dynamodb_enabled && !var.enable_server_side_encryption ? 1 : 0
   name           = local.dynamodb_table_name
   billing_mode   = var.billing_mode
   read_capacity  = var.billing_mode == "PROVISIONED" ? var.read_capacity : null

--- a/main.tf
+++ b/main.tf
@@ -249,7 +249,7 @@ resource "aws_dynamodb_table" "with_server_side_encryption" {
 }
 
 resource "aws_dynamodb_table" "without_server_side_encryption" {
-  count          = local.dynamodb_enabled && !var.enable_server_side_encryption ? 1 : 0
+  count          = local.dynamodb_enabled && ! var.enable_server_side_encryption ? 1 : 0
   name           = local.dynamodb_table_name
   billing_mode   = var.billing_mode
   read_capacity  = var.billing_mode == "PROVISIONED" ? var.read_capacity : null

--- a/replication.tf
+++ b/replication.tf
@@ -3,7 +3,7 @@ resource "aws_iam_role" "replication" {
 
   name                 = format("%s-replication", module.this.id)
   assume_role_policy   = data.aws_iam_policy_document.replication_sts[0].json
-  permissions_boundary = var.permissions_boundary
+  permissions_boundary = var.permissions_boundary ? 1 : 0
 }
 
 data "aws_iam_policy_document" "replication_sts" {

--- a/replication.tf
+++ b/replication.tf
@@ -3,7 +3,7 @@ resource "aws_iam_role" "replication" {
 
   name                 = format("%s-replication", module.this.id)
   assume_role_policy   = data.aws_iam_policy_document.replication_sts[0].json
-  permissions_boundary = var.permissions_boundary ? 1 : 0
+  permissions_boundary = var.permissions_boundary
 }
 
 data "aws_iam_policy_document" "replication_sts" {

--- a/replication.tf
+++ b/replication.tf
@@ -3,6 +3,7 @@ resource "aws_iam_role" "replication" {
 
   name               = format("%s-replication", module.this.id)
   assume_role_policy = data.aws_iam_policy_document.replication_sts[0].json
+  permissions_boundary = var.permissions_boundary  
 }
 
 data "aws_iam_policy_document" "replication_sts" {

--- a/replication.tf
+++ b/replication.tf
@@ -1,9 +1,9 @@
 resource "aws_iam_role" "replication" {
   count = local.enabled && var.s3_replication_enabled ? 1 : 0
 
-  name               = format("%s-replication", module.this.id)
-  assume_role_policy = data.aws_iam_policy_document.replication_sts[0].json
-  permissions_boundary = var.permissions_boundary  
+  name                 = format("%s-replication", module.this.id)
+  assume_role_policy   = data.aws_iam_policy_document.replication_sts[0].json
+  permissions_boundary = var.permissions_boundary
 }
 
 data "aws_iam_policy_document" "replication_sts" {

--- a/variables.tf
+++ b/variables.tf
@@ -194,3 +194,8 @@ variable "dynamodb_table_name" {
   default     = null
   description = "Override the name of the DynamoDB table which defaults to using `module.dynamodb_table_label.id`"
 }
+variable "permissions_boundary" {
+  type        = string
+  default     = ""
+  description = "ARN of the policy that is used to set the permissions boundary for the IAM role"
+}


### PR DESCRIPTION
This is my first PR to Cloudposse projects. Thanks for all the good contributions and please let me know if there's any adjustments needed. 

## what
* This will add support for setting a permission boundary for the IAM role
* This is needed for master payer accounts through resellers that restricts access to the master payer accunt. 
* The value is optional

## why
* This is needed for master payer accounts through resellers that restricts access to the master payer account and require the permissions boundary to be set on all new IAM roles to restrict access to certain resources. 

## references
* AWS documentation: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
* https://registry.terraform.io/providers/hashicorp/aws%20%20/latest/docs/resources/iam_role#permissions_boundary

