### PR TITLE
feat: tag replication role and policies

### DIFF
--- a/replication.tf
+++ b/replication.tf
@@ -3,6 +3,7 @@ resource "aws_iam_role" "replication" {
 
   name               = format("%s-replication", module.this.id)
   assume_role_policy = data.aws_iam_policy_document.replication_sts[0].json
+  tags               = module.this.tags
 }
 
 data "aws_iam_policy_document" "replication_sts" {
@@ -27,6 +28,7 @@ resource "aws_iam_policy" "replication" {
 
   name   = format("%s-replication", module.this.id)
   policy = data.aws_iam_policy_document.replication[0].json
+  tags   = module.this.tags
 }
 
 data "aws_iam_policy_document" "replication" {


### PR DESCRIPTION
## what
* This adds the same tag values to the IAM Role and Policy created for S3 replication. Previously these resources were not tagged.

## why
* In many enterprise settings, tags are required and without this enhancement, the replication functionality in the module cannot be used.
