### PR TITLE
Changes from aws terraform module

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -32,9 +32,9 @@ variable "force_destroy" {
 }
 
 variable "mfa_delete" {
-  type        = bool
+  type        = string
   description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
-  default     = false
+  default     = "Disabled"
 }
 
 variable "enable_point_in_time_recovery" {


### PR DESCRIPTION
## what
* Moving policy configuration block from the S3 bucket resource to aws_s3_bucket_policy
* Moving the server-side encryption configuration to aws_s3_bucket_server_side_encryption_configuration.
* Moving S3 bucket ACL to aws_s3_bucket_acl
* Moving S3 bucket versioning to aws_s3_bucket_versioning
* mfa_delete changed from bool to "Enabled"/"Disabled"

## why
* To suppress warnings

## references
* [AWS. Module docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)

