### PR TITLE
Do not auto-publish from release branches

### DIFF
--- a/.github/workflows/auto-release-v0.yml
+++ b/.github/workflows/auto-release-v0.yml
@@ -17,7 +17,9 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         with:
-          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
+          # Do not auto-publish until release-drafter can publish a release
+          # without making it the "latest" release.
+          publish: false
           prerelease: false
           config-name: auto-release.yml
         env:

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2020 Cloud Posse, LLC
+   Copyright 2018-2023 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -4,6 +4,8 @@ region = "us-east-2"
 
 namespace = "eg"
 
+environment = "use2"
+
 stage = "test"
 
 name = "terraform-tfstate-backend"

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -38,13 +38,13 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Run `terraform output` to get the value of an output variable
 	s3BucketId := terraform.Output(t, terraformOptions, "s3_bucket_id")
-	expectedS3BucketId := "eg-test-terraform-tfstate-backend-" + randId
+	expectedS3BucketId := "eg-use2-test-terraform-tfstate-backend-" + randId
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedS3BucketId, s3BucketId)
 
 	// Run `terraform output` to get the value of an output variable
 	dynamodbTableName := terraform.Output(t, terraformOptions, "dynamodb_table_name")
-	expectedDynamodbTableName := "eg-test-terraform-tfstate-backend-" + randId + "-lock"
+	expectedDynamodbTableName := "eg-use2-test-terraform-tfstate-backend-" + randId + "-lock"
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedDynamodbTableName, dynamodbTableName)
 }


### PR DESCRIPTION
## what

- Do not auto-publish from release branches

## why

- When `release-drafter` auto-publishes, it sets the release as "latest", which is not what we want for updates to release branches.

