### PR TITLE
fix crash: do not create policy when prevent_unencrypted_uploads is false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,10 @@ locals {
 
   prevent_unencrypted_uploads = local.enabled && var.prevent_unencrypted_uploads
 
-  policy = local.prevent_unencrypted_uploads ? join(
+  policy = join(
     "",
     data.aws_iam_policy_document.prevent_unencrypted_uploads.*.json
-  ) : ""
+  )
 
   terraform_backend_config_file = format(
     "%s/%s",
@@ -153,7 +153,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_s3_bucket_policy" "default" {
-  count = local.bucket_enabled ? 1 : 0
+  count = (local.bucket_enabled && local.prevent_unencrypted_uploads) ? 1 : 0
 
   bucket = one(aws_s3_bucket.default.*.id)
   policy = local.policy


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

This change avoids creating a policy object when `prevent_unencrypted_uploads` is set to `false`

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

With version 1.1.0, terraform apply fails with:
```
│ Error: Error putting S3 policy: MalformedPolicy: Policies must be valid JSON and the first byte must be '{'
│       status code: 400, request id: WZ7PGJ00QKNE2ZEJ, host id: qv+X4PBFIFqU6KIfIlyySSBBWRp0c4SgNFyu4Z71NJPI4x2x8uSopCZDdJ8nV96cxd+HMgG5gC4=
│ 
│   with module.s3-backend.module.terraform_state_backend.aws_s3_bucket_policy.default[0],
│   on .terraform/modules/s3-backend.terraform_state_backend/main.tf line 155, in resource "aws_s3_bucket_policy" "default":
│  155: resource "aws_s3_bucket_policy" "default" {
│ 
```

This change fixes this issue

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
