### PR TITLE
fix: Better TF formating when dynamodb_table is empty when creating backend template file

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,6 @@ data "aws_iam_policy_document" "aggregated_policy" {
   override_policy_documents = var.source_policy_documents
 }
 
-
 data "aws_iam_policy_document" "bucket_policy" {
   count = local.enabled ? 1 : 0
 

--- a/templates/terraform.tf.tpl
+++ b/templates/terraform.tf.tpl
@@ -2,14 +2,15 @@ terraform {
   required_version = ">= ${terraform_version}"
 
   backend "s3" {
-    region         = "${region}"
-    bucket         = "${bucket}"
-    key            = "${terraform_state_file}"
+    region   = "${region}"
+    bucket   = "${bucket}"
+    key      = "${terraform_state_file}"
+    profile  = "${profile}"
+    role_arn = "${role_arn}"
+    encrypt  = "${encrypt}"
+
     %{~ if dynamodb_table != "" ~}
     dynamodb_table = "${dynamodb_table}"
     %{~ endif ~}
-    profile        = "${profile}"
-    role_arn       = "${role_arn}"
-    encrypt        = "${encrypt}"
   }
 }


### PR DESCRIPTION
## what

Improve TF formatting when a DynamoDB table is not specified.

## why

As our CI pipeline checks formatting and we don't use a DynamoDB for locking, we keep committing changes made to the backend file which is handled by this module.
![image](https://github.com/cloudposse/terraform-aws-tfstate-backend/assets/10036810/92ee741e-0268-4039-a496-ddfdbb283f79)

## references
N/A