### PR TITLE
fix: s3 backend deprecated role_arn field

### DIFF
--- a/templates/terraform.tf.tpl
+++ b/templates/terraform.tf.tpl
@@ -7,13 +7,11 @@ terraform {
     key     = "${terraform_state_file}"
     profile = "${profile}"
     encrypt = "${encrypt}"
-
     %{~ if role_arn != "" ~}
     assume_role {
       role_arn = "${role_arn}"
     }
     %{~ endif ~}
-
     %{~ if dynamodb_table != "" ~}
     dynamodb_table = "${dynamodb_table}"
     %{~ endif ~}

--- a/templates/terraform.tf.tpl
+++ b/templates/terraform.tf.tpl
@@ -8,11 +8,13 @@ terraform {
     profile = "${profile}"
     encrypt = "${encrypt}"
     %{~ if role_arn != "" ~}
+
     assume_role {
       role_arn = "${role_arn}"
     }
     %{~ endif ~}
     %{~ if dynamodb_table != "" ~}
+
     dynamodb_table = "${dynamodb_table}"
     %{~ endif ~}
   }

--- a/templates/terraform.tf.tpl
+++ b/templates/terraform.tf.tpl
@@ -8,9 +8,11 @@ terraform {
     profile = "${profile}"
     encrypt = "${encrypt}"
 
+    %{~ if role_arn != "" ~}
     assume_role {
       role_arn = "${role_arn}"
     }
+    %{~ endif ~}
 
     %{~ if dynamodb_table != "" ~}
     dynamodb_table = "${dynamodb_table}"

--- a/templates/terraform.tf.tpl
+++ b/templates/terraform.tf.tpl
@@ -2,12 +2,15 @@ terraform {
   required_version = ">= ${terraform_version}"
 
   backend "s3" {
-    region   = "${region}"
-    bucket   = "${bucket}"
-    key      = "${terraform_state_file}"
-    profile  = "${profile}"
-    role_arn = "${role_arn}"
-    encrypt  = "${encrypt}"
+    region  = "${region}"
+    bucket  = "${bucket}"
+    key     = "${terraform_state_file}"
+    profile = "${profile}"
+    encrypt = "${encrypt}"
+
+    assume_role {
+      role_arn = "${role_arn}"
+    }
 
     %{~ if dynamodb_table != "" ~}
     dynamodb_table = "${dynamodb_table}"


### PR DESCRIPTION
## what

The following step was returning an error:

```
terraform init -force-copy

Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.
Initializing modules...
Terraform encountered problems during initialisation, including problems
with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Argument or block definition required
│
│   on backend.tf line 9, in terraform:
│    9:     assume_role.role_arn = ""
│
│ An argument or block definition is required here. To set an argument, use the equals sign "=" to introduce the argument value.
╵
```

