### PR TITLE
Update "mfa_delete" issue link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ https://www.terraform.io/docs/backends/types/s3.html
 
 __NOTE:__ The operators of the module (IAM Users) must have permissions to create S3 buckets and DynamoDB tables when performing `terraform plan` and `terraform apply`
 
-__NOTE:__ This module cannot be used to apply changes to the `mfa_delete` feature of the bucket. Changes regarding mfa_delete can only be made manually using the root credentials with MFA of the AWS Account where the bucket resides. Please see: https://github.com/terraform-providers/terraform-provider-aws/issues/62
+__NOTE:__ This module cannot be used to apply changes to the `mfa_delete` feature of the bucket. Changes regarding mfa_delete can only be made manually using the root credentials with MFA of the AWS Account where the bucket resides. Please see: https://github.com/terraform-providers/terraform-provider-aws/issues/629
 
 
 ---


### PR DESCRIPTION
## what

Issue number was truncated (62 instead of 629). I'm reasonably sure I found the correct issue :)

## why

Original issue link was to a completely unrelated issue (_"Handle cycles for AWS EIPs"_) which never even mentioned "mfa_delete".

## references

* before: https://github.com/hashicorp/terraform-provider-aws/issues/62
* after: https://github.com/hashicorp/terraform-provider-aws/issues/629
