### PR TITLE
Avoid manually modifying source file when destroying

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,16 +133,7 @@ Terraform configuration as usual.
 
 Follow this procedure to delete your deployment.
 
-1. In `main.tf`, change the `terraform_state_backend` module arguments as
-   follows:
-   ```hcl
-    module "terraform_state_backend" {
-      # ...
-      terraform_backend_config_file_path = ""
-      force_destroy                      = true
-    }
-    ```
-1. `terraform apply -target module.terraform_state_backend -auto-approve`.
+1. `terraform destroy -target module.terraform_state_backend.local_file.terraform_backend_config -auto-approve`.
    This implements the above modifications by deleting the `backend.tf` file
    and enabling deletion of the S3 state bucket.
 1. `terraform init -force-copy`. Terraform detects that you want to move your


### PR DESCRIPTION
## what
This PR updates the README to avoid manually modifying source file when destroying

## why

The current README requires users to manually modify source file, which is not desired


## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
