### PR TITLE
Fix assume_role handling when role_arn is given

### DIFF
--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -97,7 +97,7 @@ variable "profile" {
 variable "role_arn" {
   type        = string
   default     = ""
-  description = "The role to be assumed"
+  description = "The role to be assumed. If this is set, `terraform_version` variable must be `1.6.0` or higher."
 }
 
 variable "terraform_backend_config_file_name" {

--- a/templates/terraform.tf.tpl
+++ b/templates/terraform.tf.tpl
@@ -8,8 +8,7 @@ terraform {
     profile = "${profile}"
     encrypt = "${encrypt}"
     %{~ if role_arn != "" ~}
-
-    assume_role {
+    assume_role = {
       role_arn = "${role_arn}"
     }
     %{~ endif ~}

--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "profile" {
 variable "role_arn" {
   type        = string
   default     = ""
-  description = "The role to be assumed"
+  description = "The role to be assumed. If this is set, `terraform_version` variable must be `1.6.0` or higher."
 }
 
 variable "terraform_backend_config_file_name" {


### PR DESCRIPTION
There is a syntax error in the assume_role block with missing equals sign.

As this part has anyway required newer terraform to work, document it in variable definition of role_arn input.

Related to #171.

I did not commit `make init && make readme` outputs because there are some amount of previous unrelated changes it generates.

Tested on terraform 1.6.6 and 1.10.5 with latest 5.x provider.