### PR TITLE
docs: add S3 native locking documentation and fix variable descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,39 @@ Follow this procedure just once to create your deployment.
 This concludes the one-time preparation. Now you can extend and modify your
 Terraform configuration as usual.
 
+### S3 Native State Locking (Terraform >= 1.10)
+
+Starting with Terraform 1.10, S3 supports [native state locking](https://developer.hashicorp.com/terraform/language/backend/s3#s3-state-locking)
+via `use_lockfile = true`, removing the need for a DynamoDB table.
+
+> **Note**: DynamoDB-based state locking is [deprecated](https://developer.hashicorp.com/terraform/language/backend/s3#enabling-dynamodb-state-locking-deprecated)
+> in Terraform 1.10+. New setups should use S3 native locking instead.
+
+To use S3 native locking instead of DynamoDB:
+
+```hcl
+module "terraform_state_backend" {
+  source = "cloudposse/tfstate-backend/aws"
+
+  namespace  = "eg"
+  stage      = "test"
+  name       = "terraform"
+  attributes = ["state"]
+
+  # Use S3 native locking (Terraform >= 1.10)
+  s3_state_lock_enabled = true
+
+  # Disable DynamoDB table (not needed with S3 native locking)
+  dynamodb_enabled = false
+
+  terraform_backend_config_file_path = "."
+  terraform_backend_config_file_name = "backend.tf"
+  force_destroy                      = false
+}
+```
+
+The generated `backend.tf` will use `use_lockfile = true` instead of `dynamodb_table`.
+
 ### Destroy
 
 Follow this procedure to delete your deployment.

--- a/variables.tf
+++ b/variables.tf
@@ -182,13 +182,13 @@ variable "bucket_enabled" {
 variable "s3_state_lock_enabled" {
   type        = bool
   default     = false
-  description = "Whether to create the S3 bucket."
+  description = "Whether to use S3 native state locking (use_lockfile). Requires Terraform >= 1.10. When enabled, DynamoDB is not needed for state locking. See https://developer.hashicorp.com/terraform/language/backend/s3#s3-state-locking"
 }
 
 variable "dynamodb_enabled" {
   type        = bool
   default     = true
-  description = "Whether to create the DynamoDB table."
+  description = "Whether to create the DynamoDB table for state locking. Note: DynamoDB-based locking is deprecated in Terraform >= 1.10 in favor of S3 native locking (s3_state_lock_enabled). See https://developer.hashicorp.com/terraform/language/backend/s3#enabling-dynamodb-state-locking-deprecated"
 }
 
 variable "dynamodb_table_name" {


### PR DESCRIPTION
## what

- Fix incorrect `s3_state_lock_enabled` variable description (was "Whether to create the S3 bucket", now correctly describes S3 native state locking)
- Add deprecation note to `dynamodb_enabled` variable description linking to official Terraform docs
- Add "S3 Native State Locking" section to README with usage example

## why

- Terraform 1.10+ introduced [S3 native state locking](https://developer.hashicorp.com/terraform/language/backend/s3#s3-state-locking) via `use_lockfile = true`, deprecating DynamoDB-based locking
- The module already supports S3 native locking (`s3_state_lock_enabled` variable exists) but the documentation doesn't mention it and the variable description is incorrect
- Users are confused about how to use the module without DynamoDB (#188, #194)
- DynamoDB-based locking is [officially deprecated](https://developer.hashicorp.com/terraform/language/backend/s3#enabling-dynamodb-state-locking-deprecated)

## references

- closes #188
- closes #194
- Terraform S3 backend docs: https://developer.hashicorp.com/terraform/language/backend/s3#s3-state-locking
- DynamoDB deprecation notice: https://developer.hashicorp.com/terraform/language/backend/s3#enabling-dynamodb-state-locking-deprecated